### PR TITLE
Generate the psm1 at build time to increase startup time performance

### DIFF
--- a/.github/workflows/build-and-test-powershell-module.yml
+++ b/.github/workflows/build-and-test-powershell-module.yml
@@ -52,6 +52,10 @@ jobs:
         shell: pwsh
         run: Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit
 
+      - name: Build the concatinated psm1 file
+        shell: pwsh
+        run: ./build/Build-Psm1File.ps1
+
       - name: Run Pester Tests
         shell: pwsh
         run: |
@@ -67,10 +71,6 @@ jobs:
             CodeCoverage = @{ Enabled = $false }
           }
           Invoke-Pester -Configuration $pesterConfig
-
-      - name: Build the concatinated psm1 file
-        shell: pwsh
-        run: ./build/Build-Psm1File.ps1
 
       - name: Determine new version from Git tag and set environment variables
         shell: pwsh

--- a/.github/workflows/build-and-test-powershell-module.yml
+++ b/.github/workflows/build-and-test-powershell-module.yml
@@ -68,6 +68,10 @@ jobs:
           }
           Invoke-Pester -Configuration $pesterConfig
 
+      - name: Build the concatinated psm1 file
+        shell: pwsh
+        run: ./build/Build-Psm1File.ps1
+
       - name: Determine new version from Git tag and set environment variables
         shell: pwsh
         run: |

--- a/build/Build-Psm1File.ps1
+++ b/build/Build-Psm1File.ps1
@@ -1,13 +1,8 @@
-# This script is not currently used, but is kept around because we may decide to use it later if
-# startup performance becomes a problem down the road. For more info, see
+# This script is used in the CI/CD pipeline to generate and overwrite the tiPS.psm1 file.
+# Rather than having to dot-source all of the files into the module, this script will concatenate
+# all of the files into a single file. Dot-sourcing files at runtime is expensive and increases
+# the load time of the module, so we want to avoid it. For more info, see
 # docs/ArchitectureDecisionRecords/005-How-to-dot-source-files-into-the-module-psm1-file.md.
-
-# This script can be used to generate and overwrite the tiPS.psm1 file. Rather than having to dot-source
-# all of the files into the module, this script will concatenate all of the files into a single file.
-# Dot-sourcing files adds a runtime performance penalty, increasing the load time of the module.
-# At this time, because there are not too many files, the performance penalty is only about 100ms, which
-# is acceptable. However, if the number of files increases this script can be used to improve performance.
-# We are not using this script currently as it would add complexity to the build process and maintenance.
 
 [CmdletBinding()]
 Param()

--- a/docs/ArchitectureDecisionRecords/005-How-to-dot-source-files-into-the-module-psm1-file.md
+++ b/docs/ArchitectureDecisionRecords/005-How-to-dot-source-files-into-the-module-psm1-file.md
@@ -3,6 +3,7 @@
 ## Status
 
 Accepted 2023-09-12
+Updated 2023-09-15
 
 ## Context
 
@@ -10,6 +11,8 @@ After adding `Import-Module -Name tiPS` to my PowerShell profile, we noticed tha
 After some investigation [with Profiler](https://blog.danskingdom.com/Easily-profile-your-PowerShell-code-with-the-Profiler-module/) We found that the bulk of the time was spent dot-sourcing the files into the module.
 The alternative is to define all of the module functions directly in the .psm1 file, but having a single large file with all of the module's code in it is not ideal for organization and maintainability.
 We decided to do some performance comparisons of the different ways to define the functions in the module.
+
+One of the main benefits of the tiPS module is automatically showing tips at the start of a PowerShell session, so we want to keep the startup time as fast as possible so users are not hesitant to import the module in their PowerShell profile.
 
 ### Comparison of different ways to define functions in the module
 
@@ -39,16 +42,24 @@ Spoiler: We found it is when importing the C# classes.
 
 ## Decision
 
-While defining the functions directly in the .psm1 file is the fastest, it's not a good option for maintainability.
-To try and get the best of both worlds, we created a [build/Build-Psm1File.ps1](/build/Build-Psm1File.ps1) script that allows us to define the functions in separate files and then generate the .psm1 file with all of the functions defined in it.
-While this does accomplish the goal, it introduces additional complexity and a new script that needs to be maintained.
+Defining the functions directly in the .psm1 file is the fastest, but it's not a good option for maintainability.
+To try and get the best of both worlds, we created a [/build/Build-Psm1File.ps1](/build/Build-Psm1File.ps1) script that allows us to define the functions in separate files and then generate the .psm1 file with all of the functions defined in it.
 
-For now I'm going to stick with dot-sourcing the files individually in the .psm1 file.
-This is the simplest option and still allows us to use breakpoints in VS Code.
-Also, the performance difference between dot-sourcing and defining the code directly in the .psm1 file ~100ms, which is not too bad.
-If the dot-sourcing time becomes a problem as more files are added to the module, we can revisit this decision.
+For development, we are going to stick with dot-sourcing the files individually in the .psm1 file.
+This provides the best developer experience in terms of code organization, and still allows us to use breakpoints in VS Code.
+
+In the CI/CD pipeline, at build time we will use the [/build/Build-Psm1File.ps1](/build/Build-Psm1File.ps1) script to generate the concatenated .psm1 file with all of the functions defined directly in it.
+This will allow the published module to have the fastest startup time possible.
+
+At this time, the performance difference between dot-sourcing and defining the code directly in the .psm1 file is ~100ms.
+As more functions are added to the module, this difference would increase.
+By generating the psm1 file at build time, we are ensuring that the startup time of the module will not increase as more functions are added.
 
 ## Consequences
 
-We are sacrificing a tiny bit of startup time for maintainability and simplicity.
-As more files are added to the module, we may need to revisit this decision if the performance tradeoff becomes greater.
+While this decision accomplishes the goal of a faster startup time, it also introduces additional complexity.
+
+- The psm1 file in source control will need to be kept in sync with the [/build/Build-Psm1File.ps1](/build/Build-Psm1File.ps1) script.
+- The published module will have a different file structure and psm1 file than what is in source control, which could cause confusion and potential bugs down the road.
+
+We are sacrificing some simplicity and maintainability for startup time performance.

--- a/docs/ArchitectureDecisionRecords/005-How-to-dot-source-files-into-the-module-psm1-file.md
+++ b/docs/ArchitectureDecisionRecords/005-How-to-dot-source-files-into-the-module-psm1-file.md
@@ -3,7 +3,7 @@
 ## Status
 
 Accepted 2023-09-12
-Updated 2023-09-15
+Decision changed and ADR updated 2023-09-15
 
 ## Context
 
@@ -51,7 +51,7 @@ This provides the best developer experience in terms of code organization, and s
 In the CI/CD pipeline, at build time we will use the [/build/Build-Psm1File.ps1](/build/Build-Psm1File.ps1) script to generate the concatenated .psm1 file with all of the functions defined directly in it.
 This will allow the published module to have the fastest startup time possible.
 
-At this time, the performance difference between dot-sourcing and defining the code directly in the .psm1 file is ~100ms.
+At this time, the performance difference between dot-sourcing and defining the code directly in the .psm1 file is ~120ms.
 As more functions are added to the module, this difference would increase.
 By generating the psm1 file at build time, we are ensuring that the startup time of the module will not increase as more functions are added.
 

--- a/src/tiPS/tiPS.psm1
+++ b/src/tiPS/tiPS.psm1
@@ -1,3 +1,7 @@
+# This file is generated and overwritten in the CI/CD pipeline by the build script /build/Build-Psm1File.ps1.
+# Any changes made to this file should be reflected in that script, otherwise they will not be present
+# in the module built and deployed by the CI/CD pipeline.
+
 #Requires -Version 3.0
 Set-StrictMode -Version Latest
 


### PR DESCRIPTION
By defining the function directly in the .psm1 file at build time instead of dot-sourcing them in at runtime, we are able to reduce the startup time from ~270ms to ~150ms.