### PR TITLE
Add cmdlet for removing tiPS import from PowerShell profile

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -50,7 +50,7 @@ Paste the following commands into your PowerShell terminal to install tiPS and h
 
 ```powershell
 Install-Module -Name tiPS -Scope CurrentUser
-Edit-PowerShellProfileToImportTiPS
+Add-TiPSImportToPowerShellProfile
 Set-TiPSConfiguration -AutomaticallyWritePowerShellTip Daily -AutomaticallyUpdateModule Weekly
 ```
 
@@ -68,7 +68,7 @@ To show tips automatically, tiPS must be imported when the PowerShell session st
 To have this happen automatically you can manually add `Import-Module -Name tiPS` to your PowerShell profile, or simply run the following command to do it for you:
 
 ```powershell
-Edit-PowerShellProfileToImportTiPS
+Add-TiPSImportToPowerShellProfile
 ```
 
 ### ⚙ Recommended configuration
@@ -137,7 +137,14 @@ Automatic updates are performed in a background job, so they will not block your
 The updated module will be loaded the next time you open a PowerShell terminal or import tiPS.
 Old versions of the module are automatically deleted after a successful update.
 
-### 🔍 Test if tiPS is imported by your PowerShell profile
+### Uninstalling tiPS
+
+If you imported tiPS into your PowerShell profile, the import statement will not be removed if you just uninstall the tiPS module.
+To remove the import statement from your PowerShell profile, run the following command:
+
+```powershell
+Add-TiPSImportToPowerShellProfile -Remove
+```
 
 To see if tiPS is imported in your PowerShell profile, and in which file, run the following command:
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -71,6 +71,8 @@ To have this happen automatically you can manually add `Import-Module -Name tiPS
 Add-TiPSImportToPowerShellProfile
 ```
 
+> You can remove the import statement from your PowerShell profile by running the `Remove-TiPSImportFromPowerShellProfile` command.
+
 ### ⚙ Recommended configuration
 
 The following configuration is a good balance for displaying new tips automatically and not being overwhelmed by them.
@@ -85,17 +87,17 @@ By default tiPS does not automatically show tips or update itself, so you must c
 
 To see the full list of commands, use `Get-Command -Module tiPS`.
 You can then use `Get-Help <command>` to get more information about a specific command.
-Below are the most popular operations.
+Below are the popular operations.
 
 ### 📰 Show a tip
 
-To show a nicely formatted tip in the terminal, run the following command:
+To show a nicely formatted tip in the terminal use:
 
 ```powershell
 Write-PowerShellTip
 ```
 
-or use its alias:
+or its alias:
 
 ```powershell
 tips
@@ -111,7 +113,7 @@ Get-PowerShellTip
 
 ### 🤖 Automatic tip on PowerShell startup
 
-To have a tip automatically displayed every time you open your PowerShell terminal, run the following command:
+To have a tip automatically displayed every time you open your PowerShell terminal, run:
 
 ```powershell
 Set-TiPSConfiguration -AutomaticallyWritePowerShellTip EverySession
@@ -125,7 +127,7 @@ This prevents them from appearing unexpectedly when running scripts or other aut
 ### ⬆ Automatic updates
 
 New tips are obtained by updating the tiPS module.
-Rather than having to remember to manually update the module to see up-to-date tips, you can have the module automatically update itself by running the following command:
+Instead of remembering to manually update the module to see up-to-date tips, you can have the module automatically update itself by running:
 
 ```powershell
 Set-TiPSConfiguration -AutomaticallyUpdateModule Weekly
@@ -137,16 +139,19 @@ Automatic updates are performed in a background job, so they will not block your
 The updated module will be loaded the next time you open a PowerShell terminal or import tiPS.
 Old versions of the module are automatically deleted after a successful update.
 
-### Uninstalling tiPS
+### ❌ Uninstalling tiPS
 
 If you imported tiPS into your PowerShell profile, the import statement will not be removed if you just uninstall the tiPS module.
-To remove the import statement from your PowerShell profile, run the following command:
+If you uninstall the module without removing the import statement, you will get an error message every time you open a PowerShell terminal.
+
+If you added the import statement to your PowerShell profile using the `Add-TiPSImportToPowerShellProfile`, you can remove it with:
 
 ```powershell
-Add-TiPSImportToPowerShellProfile -Remove
+Remove-TiPSImportFromPowerShellProfile
 ```
 
-To see if tiPS is imported in your PowerShell profile, and in which file, run the following command:
+If you manually added the import statement to your PowerShell profile, you will need to remove it manually.
+To see if tiPS is being imported by your PowerShell profile, and by which file, run the command:
 
 ```powershell
 Test-PowerShellProfileImportsTiPS -Verbose
@@ -154,7 +159,7 @@ Test-PowerShellProfileImportsTiPS -Verbose
 
 ### 📁 Get directory where user configuration is stored
 
-To get the directory where the tiPS configuration and other related data is stored, run the following command:
+To get the directory where the tiPS configuration and other related data is stored, run:
 
 ```powershell
 Get-TiPSConfigurationDirectory
@@ -162,6 +167,7 @@ Get-TiPSConfigurationDirectory
 
 To restore tiPS to the default configuration, simply delete the directory.
 If tiPS is uninstalled, the directory is not automatically deleted; it must be done manually.
+The directory is very small though, so it is not a big deal if it is left behind.
 
 ## ➕ How to contribute
 

--- a/src/tiPS/Private/PowerShellProfileFunctions.ps1
+++ b/src/tiPS/Private/PowerShellProfileFunctions.ps1
@@ -1,0 +1,45 @@
+function GetPowerShellProfileFilePaths
+{
+	[string[]] $profileFilePaths = @()
+
+	# The $PROFILE variable may not exist depending on the host or the context in which PowerShell was started.
+	if (Test-Path -Path variable:PROFILE)
+	{
+		$profileFilePaths = @(
+			$PROFILE.CurrentUserAllHosts
+			$PROFILE.CurrentUserCurrentHost
+			$PROFILE.AllUsersAllHosts
+			$PROFILE.AllUsersCurrentHost
+		)
+	}
+
+	return ,$profileFilePaths
+}
+
+function GetPowerShellProfileFilePathsThatExist
+{
+	[string[]] $powerShellProfileFilePaths = GetPowerShellProfileFilePaths
+	[string[]] $profileFilePathsThatExist =
+		$powerShellProfileFilePaths |
+		Where-Object { Test-Path -Path $_ -PathType Leaf }
+
+	return ,$profileFilePathsThatExist
+}
+
+function GetPowerShellProfileFilePathToAddImportTo
+{
+	[string] $profileFilePath = [string]::Empty
+
+	# The $PROFILE variable may not exist depending on the host or the context in which PowerShell was started.
+	if (Test-Path -Path variable:PROFILE)
+	{
+		$profileFilePath = $PROFILE.CurrentUserAllHosts
+	}
+
+	return $profileFilePath
+}
+
+function GetImportStatementToAddToPowerShellProfile
+{
+	return 'Import-Module -Name tiPS # Added by tiPS to get automatic tips and updates.'
+}

--- a/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
+++ b/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
@@ -43,13 +43,18 @@ Describe 'Calling Add-TiPSImportToPowerShellProfile' {
 	Context 'When the PowerShell profile exists, and already imports tiPS' {
 		BeforeEach {
 			Mock -ModuleName $ModuleName -CommandName Test-PowerShellProfileImportsTiPS -MockWith { return $true }
-			Set-Content -Path $ProfileFilePath -Force -Value $ContentToAddToProfile
+			$fileContents = @"
+# Some code before the import statement
+$ContentToAddToProfile
+# Some code after the import statement
+"@
+			Set-Content -Path $ProfileFilePath -Force -Value $fileContents -NoNewline
 		}
 
 		It 'Should not modify the file' {
 			Add-TiPSImportToPowerShellProfile
 
-			Get-Content -Path $ProfileFilePath | Should -Be $ContentToAddToProfile
+			Get-Content -Path $ProfileFilePath -Raw | Should -Be $fileContents
 		}
 	}
 }

--- a/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
+++ b/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
@@ -1,7 +1,7 @@
 using module './../tiPS.psm1'
 
 BeforeAll {
-	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking public functions called by the module.
+	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking functions called by the module.
 }
 
 Describe 'Calling Add-TiPSImportToPowerShellProfile' {

--- a/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
+++ b/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
 	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking public functions called by the module.
 }
 
-Describe 'Calling Edit-PowerShellProfileToImportTiPS' {
+Describe 'Calling Add-TiPSImportToPowerShellProfile' {
 	BeforeEach {
 		New-Variable -Name ContentToAddToProfile -Value 'Import-Module -Name tiPS # Added by tiPS to get automatic tips and updates.'
 
@@ -18,7 +18,7 @@ Describe 'Calling Edit-PowerShellProfileToImportTiPS' {
 		}
 
 		It 'Should create the file with the import statement' {
-			Edit-PowerShellProfileToImportTiPS
+			Add-TiPSImportToPowerShellProfile
 
 			Get-Content -Path $ProfileFilePath | Should -Be $ContentToAddToProfile
 		}
@@ -32,7 +32,7 @@ Describe 'Calling Edit-PowerShellProfileToImportTiPS' {
 		}
 
 		It 'Should add the import statement to the file' {
-			Edit-PowerShellProfileToImportTiPS
+			Add-TiPSImportToPowerShellProfile
 
 			$expectedContent = $existingProfileContent + [System.Environment]::NewLine +
 				$ContentToAddToProfile + [System.Environment]::NewLine
@@ -47,7 +47,7 @@ Describe 'Calling Edit-PowerShellProfileToImportTiPS' {
 		}
 
 		It 'Should not modify the file' {
-			Edit-PowerShellProfileToImportTiPS
+			Add-TiPSImportToPowerShellProfile
 
 			Get-Content -Path $ProfileFilePath | Should -Be $ContentToAddToProfile
 		}

--- a/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
+++ b/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Calling Add-TiPSImportToPowerShellProfile' {
 		New-Variable -Name ContentToAddToProfile -Value 'Import-Module -Name tiPS # Added by tiPS to get automatic tips and updates.'
 
 		[string] $ProfileFilePath = 'TestDrive:/fakeProfile.ps1'
-		Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePath -MockWith { return $ProfileFilePath }
+		Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathToAddImportTo -MockWith { return $ProfileFilePath }
 	}
 
 	Context 'When the PowerShell profile does not exist' {

--- a/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.ps1
+++ b/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.ps1
@@ -2,7 +2,7 @@ function Add-TiPSImportToPowerShellProfile
 {
 <#
 	.SYNOPSIS
-	Edits the user's PowerShell profile file to import the tiPS module.
+	Adds the tiPS Import-Module statement to the user's PowerShell profile file.
 
 	.DESCRIPTION
 	This function edits the user's PowerShell profile file to import the tiPS module, which can provide
@@ -20,7 +20,7 @@ function Add-TiPSImportToPowerShellProfile
 	.EXAMPLE
 	Add-TiPSImportToPowerShellProfile
 
-	This example edits the PowerShell profile to import the tiPS module.
+	This example edits the PowerShell profile to add a tiPS Import-Module statement.
 #>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	[OutputType([void])]
@@ -35,8 +35,8 @@ function Add-TiPSImportToPowerShellProfile
 			return
 		}
 
-		[string] $profileFilePath = GetPowerShellProfileFilePath
-		[string] $contentToAddToProfile = 'Import-Module -Name tiPS # Added by tiPS to get automatic tips and updates.'
+		[string] $profileFilePath = GetPowerShellProfileFilePathToAddImportTo
+		[string] $contentToAddToProfile = GetImportStatementToAddToPowerShellProfile
 
 		if ([string]::IsNullOrWhiteSpace($profileFilePath))
 		{
@@ -59,18 +59,4 @@ function Add-TiPSImportToPowerShellProfile
 			Add-Content -Path $profileFilePath -Value $contentToAddToProfile -Force
 		}
 	}
-}
-
-# Use a function to get the file path so we can mock this function for testing.
-function GetPowerShellProfileFilePath
-{
-	[string] $profileFilePath = [string]::Empty
-
-	# The $PROFILE variable may not exist depending on the host or the context in which PowerShell was started.
-	if (Test-Path -Path variable:PROFILE)
-	{
-		$profileFilePath = $PROFILE.CurrentUserAllHosts
-	}
-
-	return $profileFilePath
 }

--- a/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.ps1
+++ b/src/tiPS/Public/Add-TiPSImportToPowerShellProfile.ps1
@@ -1,4 +1,4 @@
-function Edit-PowerShellProfileToImportTiPS
+function Add-TiPSImportToPowerShellProfile
 {
 <#
 	.SYNOPSIS
@@ -18,7 +18,7 @@ function Edit-PowerShellProfileToImportTiPS
 	None. The function does not return any objects.
 
 	.EXAMPLE
-	Edit-PowerShellProfileToImportTiPS
+	Add-TiPSImportToPowerShellProfile
 
 	This example edits the PowerShell profile to import the tiPS module.
 #>

--- a/src/tiPS/Public/Remove-TiPSImportFromPowerShellProfile.Tests.ps1
+++ b/src/tiPS/Public/Remove-TiPSImportFromPowerShellProfile.Tests.ps1
@@ -1,0 +1,39 @@
+using module './../tiPS.psm1'
+
+BeforeAll {
+	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking functions called by the module.
+}
+
+Describe 'Calling Remove-TiPSImportFromPowerShellProfile' {
+	BeforeEach {
+		New-Variable -Name ContentToAddToProfile -Value 'Import-Module -Name tiPS # Added by tiPS to get automatic tips and updates.'
+
+		[string] $ProfileFilePath = 'TestDrive:/fakeProfile.ps1'
+		Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return @($ProfileFilePath) }
+	}
+
+	Context 'When no PowerShell profiles import the tiPS module' {
+		BeforeEach {
+			Mock -ModuleName $ModuleName -CommandName Test-PowerShellProfileImportsTiPS -MockWith { return $false }
+		}
+
+		It 'Should should not do anything' {
+			$verboseOutput = Remove-TiPSImportFromPowerShellProfile -Verbose 4>&1
+
+			$verboseOutput | Should -BeLike '*no changes are necessary*'
+		}
+	}
+
+	Context 'When a PowerShell profile that imports tiPS exists' {
+		BeforeEach {
+			Mock -ModuleName $ModuleName -CommandName Test-PowerShellProfileImportsTiPS -MockWith { return $true }
+			Set-Content -Path $ProfileFilePath -Force -Value $ContentToAddToProfile
+		}
+
+		It 'Should remove the import statement from the profile file' {
+			Remove-TiPSImportFromPowerShellProfile
+
+			Get-Content -Path $ProfileFilePath | Should -Not -Contain $ContentToAddToProfile
+		}
+	}
+}

--- a/src/tiPS/Public/Remove-TiPSImportFromPowerShellProfile.ps1
+++ b/src/tiPS/Public/Remove-TiPSImportFromPowerShellProfile.ps1
@@ -1,0 +1,66 @@
+function Remove-TiPSImportFromPowerShellProfile
+{
+<#
+	.SYNOPSIS
+	Removes the tiPS Import-Module statement from the user's PowerShell profile file.
+
+	.DESCRIPTION
+	This function edits the user's PowerShell profile file to remove the Import-Module statement that is
+	used to import the tiPS module. If the profile does not import the tiPS module, then no changes are made.
+	Only the default PowerShell profile paths are searched to see if the tiPS module is imported; if
+	it is imported from a dot-sourced script, the function will not detect the import statement and it will
+	not be removed.
+
+	This function will only remove the tiPS import statement added by the Add-TiPSImportToPowerShellProfile
+	function. If you manually added the import statement to your profile, this function may not remove it.
+
+	.INPUTS
+	None. You cannot pipe objects to the function.
+
+	.OUTPUTS
+	None. The function does not return any objects.
+
+	.EXAMPLE
+	Remove-TiPSImportFromPowerShellProfile
+
+	This example edits the PowerShell profile to remove the tiPS Import-Module statement.
+#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	[OutputType([void])]
+	Param()
+
+	Process
+	{
+		[bool] $moduleImportStatementIsInProfile = Test-PowerShellProfileImportsTiPS
+		if (-not $moduleImportStatementIsInProfile)
+		{
+			Write-Verbose "The PowerShell profiles do not import the tiPS module, so no changes are necessary."
+			return
+		}
+
+		[string[]] $profileFilePathsThatExist = GetPowerShellProfileFilePathsThatExist
+		[string] $contentToRemoveFromProfile = GetImportStatementToAddToPowerShellProfile
+
+		[bool] $atLeastOneProfileFileModified = $false
+		foreach ($profileFilePath in $profileFilePathsThatExist)
+		{
+			[string] $fileContents = Get-Content -Path $profileFilePath -Raw
+			if ($fileContents.Contains($contentToRemoveFromProfile))
+			{
+				if ($PSCmdlet.ShouldProcess("PowerShell profile '$profileFilePath'", 'Update'))
+				{
+					Write-Verbose "Removing '$contentToRemoveFromProfile' from PowerShell profile '$profileFilePath'."
+					[string] $updatedFileContents = $fileContents -replace $contentToRemoveFromProfile, ''
+					Set-Content -Path $profileFilePath -Value $updatedFileContents -Force
+				}
+
+				$atLeastOneProfileFileModified = $true
+			}
+		}
+
+		if (-not $atLeastOneProfileFileModified)
+		{
+			Write-Warning "One of the PowerShell profiles does import the tiPS module, but not with the expected import statement '$contentToRemoveFromProfile'. Run 'Test-PowerShellProfileImportsTiPS -Verbose' to see which profile files import the tiPS module, and then manually remove the statement from the file."
+		}
+	}
+}

--- a/src/tiPS/Public/Set-TiPSConfiguration.Tests.ps1
+++ b/src/tiPS/Public/Set-TiPSConfiguration.Tests.ps1
@@ -1,7 +1,7 @@
 using module './../tiPS.psm1'
 
 BeforeAll {
-	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking public functions called by the module.
+	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking functions called by the module.
 }
 
 Describe 'Setting the Configuration' {

--- a/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.Tests.ps1
+++ b/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.Tests.ps1
@@ -1,11 +1,13 @@
+using module './../tiPS.psm1'
+
 BeforeAll {
-	. "$PSScriptRoot/Test-PowerShellProfileImportsTiPS.ps1"
+	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking functions called by the module.
 }
 
 Describe 'Calling Test-PowerShellProfileImportsTiPS' {
 	Context 'When the PowerShell profile files do not exist' {
 		BeforeEach {
-			Mock -CommandName GetPowerShellProfileFilePaths -MockWith { return @('TestDrive:/DoesNotExist.ps1') }
+			Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return $null }
 		}
 
 		It 'Should return false' {
@@ -20,7 +22,7 @@ Describe 'Calling Test-PowerShellProfileImportsTiPS' {
 			Set-Content -Path $fakeProfileFilePath -Force -Value @'
 # This is a fake PowerShell profile.
 '@
-			Mock -CommandName GetPowerShellProfileFilePaths -MockWith { return @($fakeProfileFilePath) }
+			Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return @($fakeProfileFilePath) }
 		}
 
 		It 'Should return false' {
@@ -36,7 +38,7 @@ Describe 'Calling Test-PowerShellProfileImportsTiPS' {
 # This fake PowerShell profile imports tiPS.
 Import-Module -Name tiPS
 '@
-			Mock -CommandName GetPowerShellProfileFilePaths -MockWith { return @($fakeProfileFilePath) }
+			Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return @($fakeProfileFilePath) }
 		}
 
 		It 'Should return true' {

--- a/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.Tests.ps1
+++ b/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.Tests.ps1
@@ -5,7 +5,7 @@ BeforeAll {
 }
 
 Describe 'Calling Test-PowerShellProfileImportsTiPS' {
-	Context 'When the PowerShell profile files do not exist' {
+	Context 'When no PowerShell profile files exist' {
 		BeforeEach {
 			Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return $null }
 		}
@@ -34,14 +34,45 @@ Describe 'Calling Test-PowerShellProfileImportsTiPS' {
 	Context 'When the PowerShell profiles exist and do import tiPS' {
 		BeforeEach {
 			$fakeProfileFilePath = 'TestDrive:/fakeProfile.ps1'
+			Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return @($fakeProfileFilePath) }
+		}
+
+		It 'Should return true when the profile uses the standard import statement' {
 			Set-Content -Path $fakeProfileFilePath -Force -Value @'
 # This fake PowerShell profile imports tiPS.
 Import-Module -Name tiPS
 '@
-			Mock -ModuleName $ModuleName -CommandName GetPowerShellProfileFilePathsThatExist -MockWith { return @($fakeProfileFilePath) }
+
+			$result = Test-PowerShellProfileImportsTiPS
+			$result | Should -Be $true
 		}
 
-		It 'Should return true' {
+		It 'Should return true when the profile uses the an abbreviated import statement' {
+			Set-Content -Path $fakeProfileFilePath -Force -Value @'
+# This fake PowerShell profile imports tiPS.
+Import-Module tiPS
+'@
+
+			$result = Test-PowerShellProfileImportsTiPS
+			$result | Should -Be $true
+		}
+
+		It 'Should return true when the profile uses the automatically added import statement' {
+			Set-Content -Path $fakeProfileFilePath -Force -Value @'
+# This fake PowerShell profile imports tiPS.
+'Import-Module -Name tiPS # Added by tiPS to get automatic tips and updates.'
+'@
+
+			$result = Test-PowerShellProfileImportsTiPS
+			$result | Should -Be $true
+		}
+
+		It 'Should return true when the profile uses an import statement with additional parameters' {
+			Set-Content -Path $fakeProfileFilePath -Force -Value @'
+# This fake PowerShell profile imports tiPS.
+Import-Module -Force -Name tiPS -Verbose
+'@
+
 			$result = Test-PowerShellProfileImportsTiPS
 			$result | Should -Be $true
 		}

--- a/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.ps1
+++ b/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.ps1
@@ -32,10 +32,7 @@ function Test-PowerShellProfileImportsTiPS
 	[OutputType([System.Boolean])]
 	Param()
 
-	[string[]] $powerShellProfileFilePaths = GetPowerShellProfileFilePaths
-	[string[]] $profileFilePathsThatExist =
-		$powerShellProfileFilePaths |
-		Where-Object { Test-Path -Path $_ -PathType Leaf }
+	[string[]] $profileFilePathsThatExist = GetPowerShellProfileFilePathsThatExist
 
 	if ($null -eq $profileFilePathsThatExist -or $profileFilePathsThatExist.Count -eq 0)
 	{
@@ -57,23 +54,4 @@ function Test-PowerShellProfileImportsTiPS
 
 	Write-Verbose "The tiPS module is not imported by any of the PowerShell profiles: $profileFilePathsThatExist"
 	return $false
-}
-
-# Use a function to get the file paths so we can mock this function for testing.
-function GetPowerShellProfileFilePaths
-{
-	[string[]] $profileFilePaths = @()
-
-	# The $PROFILE variable may not exist depending on the host or the context in which PowerShell was started.
-	if (Test-Path -Path variable:PROFILE)
-	{
-		$profileFilePaths = @(
-			$PROFILE.CurrentUserAllHosts
-			$PROFILE.CurrentUserCurrentHost
-			$PROFILE.AllUsersAllHosts
-			$PROFILE.AllUsersCurrentHost
-		)
-	}
-
-	return ,$profileFilePaths
 }

--- a/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.ps1
+++ b/src/tiPS/Public/Test-PowerShellProfileImportsTiPS.ps1
@@ -52,6 +52,6 @@ function Test-PowerShellProfileImportsTiPS
 		return $true
 	}
 
-	Write-Verbose "The tiPS module is not imported by any of the PowerShell profiles: $profileFilePathsThatExist"
+	Write-Verbose "The tiPS module is not imported directly by any of the PowerShell profiles: $profileFilePathsThatExist"
 	return $false
 }

--- a/src/tiPS/Public/Write-PowerShellTip.Tests.ps1
+++ b/src/tiPS/Public/Write-PowerShellTip.Tests.ps1
@@ -5,7 +5,7 @@ using module './../tiPS.psm1'
 Param()
 
 BeforeAll {
-	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking public functions called by the module.
+	New-Variable -Name ModuleName -Value 'tiPS' -Option Constant -Force # Required for mocking functions called by the module.
 }
 
 Describe 'Write-PowerShellTip' {

--- a/src/tiPS/tiPS.psd1
+++ b/src/tiPS/tiPS.psd1
@@ -76,6 +76,7 @@ FunctionsToExport = @(
   'Set-TiPSConfiguration'
   'Get-TiPSDataDirectoryPath'
   'Add-TiPSImportToPowerShellProfile'
+  'Remove-TiPSImportFromPowerShellProfile'
   'Test-PowerShellProfileImportsTiPS'
 )
 

--- a/src/tiPS/tiPS.psd1
+++ b/src/tiPS/tiPS.psd1
@@ -75,7 +75,7 @@ FunctionsToExport = @(
   'Get-TiPSConfiguration'
   'Set-TiPSConfiguration'
   'Get-TiPSDataDirectoryPath'
-  'Edit-PowerShellProfileToImportTiPS'
+  'Add-TiPSImportToPowerShellProfile'
   'Test-PowerShellProfileImportsTiPS'
 )
 


### PR DESCRIPTION
feat: Add cmdlet for removing tiPS import from PowerShell profile.
refactor: Rename `Edit-PowerShellProfileToImportTiPS` cmdlet for clarity.
test: Add and update test cases.
docs: Update ReadMe with uninstall information