### PR TITLE
Fix bugs with internal tools and tests when the C# assemblies have not been built yet

### DIFF
--- a/.github/workflows/build-and-test-powershell-module.yml
+++ b/.github/workflows/build-and-test-powershell-module.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build the C# assemblies
         shell: pwsh
-        run: ./build/Build-CSharpAssemblies.ps1
+        run: ./build/Build-CSharpAssemblies.ps1 -Force
 
       - name: Generate PowerShellTips.json file
         shell: pwsh

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
 						"-Command"
 					]}
 			},
-			"command": "Invoke-Pester -Configuration (New-PesterConfiguration @{ Output = @{ Verbosity = 'Detailed' }})",
+			"command": "./build/Build-CSharpAssemblies.ps1; Invoke-Pester -Configuration (New-PesterConfiguration @{ Output = @{ Verbosity = 'Detailed' }})",
 			"group": "test",
 			"presentation": {
 				"reveal": "always",
@@ -55,7 +55,10 @@
 				"panel": "dedicated",
 				"clear": true,
 				"group": "build"
-			}
+			},
+			"problemMatcher": [
+				"$func-powershell-watch"
+			]
 		},
 		{
 			"label": "Convert PowerShellTips files to JSON file",
@@ -84,6 +87,15 @@
 		{
 			"label": "Ensure PowerShellTips filenames match their ID",
 			"type": "shell",
+			"options": {
+				"shell": {
+					"executable": "pwsh",
+					"args": [
+						"-NoProfile",
+						"-Command"
+					]
+				}
+			},
 			"command": "./tools/Rename-PowerShellTipFilesToMatchTheirId.ps1",
 			"group": "build",
 			"presentation": {
@@ -99,7 +111,16 @@
 		{
 			"label": "Build C# assembly and copy to PowerShell module directory",
 			"type": "shell",
-			"command": "./build/Build-CSharpAssemblies.ps1",
+			"options": {
+				"shell": {
+					"executable": "pwsh",
+					"args": [
+						"-NoProfile",
+						"-Command"
+					]
+				}
+			},
+			"command": "./build/Build-CSharpAssemblies.ps1 -Force",
 			"group": "build",
 			"presentation": {
 				"reveal": "always",
@@ -111,12 +132,20 @@
 		{
 			"label": "Add new PowerShell tip",
 			"type": "shell",
+			"options": {
+				"shell": {
+					"executable": "pwsh",
+					"args": [
+						"-NoProfile",
+						"-Command"
+					]
+				}
+			},
 			"command": "./tools/New-PowerShellTip.ps1",
 			"group": "none",
 			"presentation": {
 				"reveal": "always"
-			},
-			"problemMatcher": []
+			}
 		}
 	]
 }

--- a/build/Build-CSharpAssemblies.ps1
+++ b/build/Build-CSharpAssemblies.ps1
@@ -1,7 +1,11 @@
 # This script builds the C# DLL files and places them in the Classes directory of the module.
 
 [CmdletBinding()]
-Param()
+Param
+(
+	[Parameter(Mandatory = $false, HelpMessage = 'If specified, the module DLL files will be rebuilt even if they already exist. Otherwise, they will only be built if they do not exist.')]
+	[switch] $Force
+)
 
 [string] $repositoryRoot = Split-Path $PSScriptRoot -Parent -Resolve
 [string] $moduleDirectoryPath = Join-Path -Path $repositoryRoot -ChildPath 'src/tiPS'
@@ -10,12 +14,19 @@ Param()
 [string] $csharpSlnFilePath = Join-Path -Path $csharpSolutionDirectoryPath -ChildPath 'tiPSClasses.sln'
 [string] $csharpClassesDllDirectoryPath = Join-Path -Path $csharpSolutionDirectoryPath -ChildPath 'tiPSClasses/bin/Release/netstandard2.0'
 
+[bool] $assembliesAreAlreadyBuilt = (Test-Path -Path $moduleClassesDirectoryPath/*.dll -PathType Leaf)
+if ($assembliesAreAlreadyBuilt -and -not $Force)
+{
+	Write-Verbose "The tiPS C# assemblies are already built. Skipping the build."
+	return
+}
+
 Write-Output "Deleting the DLL files in '$moduleClassesDirectoryPath' before rebuilding and replacing them."
 Remove-Item -Path "$moduleClassesDirectoryPath/*" -Include '*.dll' -Force -ErrorVariable removeDllFilesError
 
 if ($removeDllFilesError)
 {
-	throw "Error deleting the DLL files in '$moduleClassesDirectoryPath'. They are likely in use by another process that imported tiPS. Try closing all PowerShell sessions and running the build script again. Error: $removeDllFilesError"
+	throw "Error deleting the DLL files in '$moduleClassesDirectoryPath'. They are likely in use by another process that imported tiPS. Try closing all PowerShell sessions and running the script again. Error: $removeDllFilesError"
 }
 
 Write-Output "Building C# sln '$csharpSlnFilePath' in Release mode."

--- a/tools/Helpers/ImportBuiltModule.ps1
+++ b/tools/Helpers/ImportBuiltModule.ps1
@@ -1,0 +1,8 @@
+# This is a helper script to build the tiPS C# assemblies if needed and then import the module.
+
+[string] $buildScriptPath = Resolve-Path -Path "$PSScriptRoot/../../build/Build-CSharpAssemblies.ps1"
+[string] $moduleDirectoryPath = Resolve-Path -Path "$PSScriptRoot/../../src/tiPS"
+
+& $buildScriptPath
+
+Import-Module $moduleDirectoryPath -Force

--- a/tools/New-PowerShellTip.ps1
+++ b/tools/New-PowerShellTip.ps1
@@ -1,9 +1,9 @@
 # Run this script to create a new PowerShell Tip file and open it.
 # You will be prompted for the tip's title, and then the file will open in your default editor.
 
-using module './../src/tiPS'
-
 [string] $tipTitle = Read-Host -Prompt 'Enter the title for your new PowerShell tip (e.g. "PowerShell is open source")'
+
+. "$PSScriptRoot/Helpers/ImportBuiltModule.ps1"
 
 # The Tip filename is based on the ID, which is based on the date and title, so load a dummy PowerShellTip to get the filename to use.
 $dummyTip = [tiPS.PowerShellTip]::new()

--- a/tools/Rename-PowerShellTipFilesToMatchTheirId.ps1
+++ b/tools/Rename-PowerShellTipFilesToMatchTheirId.ps1
@@ -2,7 +2,7 @@
 # This script can be run on-demand when a Pester test complains that a file is not named correctly.
 # It is also run as part of the default VS Code build task.
 
-using module './../src/tiPS'
+. "$PSScriptRoot/Helpers/ImportBuiltModule.ps1"
 
 [string] $powerShellTipFilesDirectoryPath = Resolve-Path -Path "$PSScriptRoot/../src/PowerShellTips"
 


### PR DESCRIPTION
chore: Add Force parameter to build script, and only build the project when it is not already built
chore: Build the module if needed before running tests or internal tools