### PR TITLE
feat: Ensure all tip strings are trimmed

### DIFF
--- a/build/Convert-PowerShellTipFilesToJsonFile.ps1
+++ b/build/Convert-PowerShellTipFilesToJsonFile.ps1
@@ -35,6 +35,7 @@ foreach ($tipFilePath in $tipFilePaths)
 	$tip = $null
 	. $tipFilePath
 
+	$tip.TrimAllProperties()
 	$tip.Validate()
 	$tips.Add($tip) > $null
 }

--- a/src/CSharpClasses/tiPSClasses/PowerShellTip.cs
+++ b/src/CSharpClasses/tiPSClasses/PowerShellTip.cs
@@ -55,6 +55,18 @@ namespace tiPS
 			get { return !string.IsNullOrWhiteSpace(MinPowerShellVersion) && MinPowerShellVersion != "0.0"; }
 		}
 
+		public void TrimAllProperties()
+		{
+			Title = Title.Trim();
+			TipText = TipText.Trim();
+			Example = Example.Trim();
+			MinPowerShellVersion = MinPowerShellVersion.Trim();
+			for (int i = 0; i < Urls.Length; i++)
+			{
+				Urls[i] = Urls[i].Trim();
+			}
+		}
+
 		public void Validate()
 		{
 			if (CreatedDate == DateTime.MinValue)

--- a/src/CSharpClasses/tiPSClasses/PowerShellTip.cs
+++ b/src/CSharpClasses/tiPSClasses/PowerShellTip.cs
@@ -45,6 +45,11 @@ namespace tiPS
 			}
 		}
 
+		public bool ExampleIsProvided
+		{
+			get { return !string.IsNullOrWhiteSpace(Example); }
+		}
+
 		public bool UrlsAreProvided
 		{
 			get { return Urls != null && Urls.Length > 0; }

--- a/src/tiPS/Classes/PowerShellTip.Tests.ps1
+++ b/src/tiPS/Classes/PowerShellTip.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'Trimming all tip properties' {
 			$validTip.Category = 'Community'
 		}
 
-		It 'Should trim the whitespace from all of the properties' {
+		It 'Should trim the leading and trailing whitespace from all of the properties' {
 			[tiPS.PowerShellTip] $tip = $validTip
 			[string] $title = ' Title of the tip '
 			[string] $expectedTitle = 'Title of the tip'

--- a/src/tiPS/Classes/PowerShellTip.Tests.ps1
+++ b/src/tiPS/Classes/PowerShellTip.Tests.ps1
@@ -1,5 +1,82 @@
 using module './../tiPS.psm1'
 
+Describe 'Trimming all tip properties' {
+	Context 'Given none of the properties need whitespace trimmed' {
+		BeforeEach {
+			[tiPS.PowerShellTip] $validTip = [tiPS.PowerShellTip]::new()
+			$validTip.CreatedDate = [DateTime]::Parse('2023-07-16')
+			$validTip.Title = 'Title of the tip'
+			$validTip.TipText = 'Tip Text'
+			$validTip.Example = 'Example'
+			$validTip.Urls = @('https://Url1.com', 'http://Url2.com')
+			$validTip.MinPowerShellVersion = '5.1'
+			$validTip.Category = 'Community'
+		}
+
+		It 'Should not change any of the properties' {
+			[tiPS.PowerShellTip] $tip = $validTip
+			[string] $title = 'Title of the tip'
+			[string] $tipText = 'Tip Text'
+			[string] $example = 'Example'
+			[string[]] $urls = @('https://Url1.com', 'http://Url2.com')
+			[string] $minPowerShellVersion = '5.1'
+			$tip.Title = $title
+			$tip.TipText = $tipText
+			$tip.Example = $example
+			$tip.Urls = $urls
+			$tip.MinPowerShellVersion = $minPowerShellVersion
+
+			{ $tip.TrimAllProperties() } | Should -Not -Throw
+
+			$tip.Title | Should -Be $title
+			$tip.TipText | Should -Be $tipText
+			$tip.Example | Should -Be $example
+			$tip.Urls | Should -Be $urls
+			$tip.MinPowerShellVersion | Should -Be $minPowerShellVersion
+		}
+	}
+
+	Context 'Given the properties need whitespace trimmed' {
+		BeforeEach {
+			[tiPS.PowerShellTip] $validTip = [tiPS.PowerShellTip]::new()
+			$validTip.CreatedDate = [DateTime]::Parse('2023-07-16')
+			$validTip.Title = 'Title of the tip'
+			$validTip.TipText = 'Tip Text'
+			$validTip.Example = 'Example'
+			$validTip.Urls = @('https://Url1.com', 'http://Url2.com')
+			$validTip.MinPowerShellVersion = '5.1'
+			$validTip.Category = 'Community'
+		}
+
+		It 'Should trim the whitespace from all of the properties' {
+			[tiPS.PowerShellTip] $tip = $validTip
+			[string] $title = ' Title of the tip '
+			[string] $expectedTitle = 'Title of the tip'
+			[string] $tipText = '	Tip Text	'
+			[string] $expectedTipText = 'Tip Text'
+			[string] $example = ' Example'
+			[string] $expectedExample = 'Example'
+			[string[]] $urls = @('https://Url1.com   ', '   http://Url2.com')
+			[string[]] $expectedUrls = @('https://Url1.com', 'http://Url2.com')
+			[string] $minPowerShellVersion = '5.1 '
+			[string] $expectedMinPowerShellVersion = '5.1'
+			$tip.Title = $title
+			$tip.TipText = $tipText
+			$tip.Example = $example
+			$tip.Urls = $urls
+			$tip.MinPowerShellVersion = $minPowerShellVersion
+
+			{ $tip.TrimAllProperties() } | Should -Not -Throw
+
+			$tip.Title | Should -Be $expectedTitle
+			$tip.TipText | Should -Be $expectedTipText
+			$tip.Example | Should -Be $expectedExample
+			$tip.Urls | Should -Be $expectedUrls
+			$tip.MinPowerShellVersion | Should -Be $expectedMinPowerShellVersion
+		}
+	}
+}
+
 Describe 'Validating a PowerShellTip' {
 	Context 'Given the PowerShellTip has invalid properties' {
 		BeforeEach {

--- a/src/tiPS/Private/WritePowerShellTipToTerminal.ps1
+++ b/src/tiPS/Private/WritePowerShellTipToTerminal.ps1
@@ -36,7 +36,7 @@ function WritePowerShellTipToTerminal
 
 	Write-Host $Tip.TipText -ForegroundColor $tipTextColor
 
-	if (-not [string]::IsNullOrWhiteSpace($Tip.Example))
+	if ($Tip.ExampleIsProvided)
 	{
 		Write-Host 'Example: ' -ForegroundColor $exampleColor -NoNewline
 		Write-Host $Tip.Example -ForegroundColor $exampleColor

--- a/tools/New-PowerShellTip.ps1
+++ b/tools/New-PowerShellTip.ps1
@@ -23,7 +23,9 @@ A short description of the tip.
 
 This can be multiple lines.
 '@
-`$tip.Example = 'Example code to demonstrate the tip. This can also be multiple lines if needed.'
+`$tip.Example = @'
+Example code to demonstrate the tip. This can also be multiple lines if needed.
+'@
 `$tip.Urls = @(
 	'https://OneTwoOrThreeUrls'
 	'https://ToLearnMoreAboutTheTip'


### PR DESCRIPTION
To avoid displaying excess whitespace, ensure all tips have their string properties trimmed of leading and trailing whitespace