### PR TITLE
Remove the MinPowerShellVersion tip property

### DIFF
--- a/src/CSharpClasses/tiPSClasses/PowerShellTip.cs
+++ b/src/CSharpClasses/tiPSClasses/PowerShellTip.cs
@@ -21,7 +21,6 @@ namespace tiPS
 		public string TipText { get; set; }
 		public string Example { get; set; }
 		public string[] Urls { get; set; }
-		public string MinPowerShellVersion { get; set; } // Use a string because System.Version is not deserialized correctly from JSON, and it's a bit more user friendly when specifying the version.
 		public TipCategory Category { get; set; }
 
 		public PowerShellTip()
@@ -31,7 +30,6 @@ namespace tiPS
 			TipText = string.Empty;
 			Example = string.Empty;
 			Urls = Array.Empty<string>();
-			MinPowerShellVersion = string.Empty;
 			Category = TipCategory.Other;
 		}
 
@@ -55,17 +53,11 @@ namespace tiPS
 			get { return Urls != null && Urls.Length > 0; }
 		}
 
-		public bool MinPowerShellVersionIsProvided
-		{
-			get { return !string.IsNullOrWhiteSpace(MinPowerShellVersion) && MinPowerShellVersion != "0.0"; }
-		}
-
 		public void TrimAllProperties()
 		{
 			Title = Title.Trim();
 			TipText = TipText.Trim();
 			Example = Example.Trim();
-			MinPowerShellVersion = MinPowerShellVersion.Trim();
 			for (int i = 0; i < Urls.Length; i++)
 			{
 				Urls[i] = Urls[i].Trim();
@@ -117,26 +109,6 @@ namespace tiPS
 				if (!isValidUrl)
 				{
 					throw new ArgumentException("The Urls property value '" + url + "' is not a valid URL.");
-				}
-			}
-
-			if (MinPowerShellVersionIsProvided)
-			{
-				Version version;
-				bool isValidVersionNumber = Version.TryParse(MinPowerShellVersion, out version);
-				if (!isValidVersionNumber)
-				{
-					throw new ArgumentException("The MinPowerShellVersion property value '" + MinPowerShellVersion + "' is not a valid version number.");
-				}
-
-				if (version == new Version(0, 0) && MinPowerShellVersion != "0.0")
-				{
-					throw new ArgumentException("To specify that there is no minimum PowerShell version, use a MinPowerShellVersion property value of '0.0' instead of '" + MinPowerShellVersion + "'.");
-				}
-
-				if (version.Build > 0 || version.Revision > 0)
-				{
-					throw new ArgumentException("The MinPowerShellVersion property value should be of the format 'Major.Minor'. The value '" + MinPowerShellVersion + "' is not valid.");
 				}
 			}
 		}

--- a/src/PowerShellTips/2023-07-16-powershell-is-open-source.ps1
+++ b/src/PowerShellTips/2023-07-16-powershell-is-open-source.ps1
@@ -6,5 +6,4 @@ $tip.Example = ''
 $tip.Urls = @(
 	'https://github.com/PowerShell/PowerShell'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Community

--- a/src/PowerShellTips/2023-07-17-set-strict-mode-on-your-scripts.ps1
+++ b/src/PowerShellTips/2023-07-17-set-strict-mode-on-your-scripts.ps1
@@ -6,5 +6,4 @@ $tip.Example = 'Set-StrictMode -Version Latest'
 $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax

--- a/src/PowerShellTips/2023-08-28-view-your-command-line-history.ps1
+++ b/src/PowerShellTips/2023-08-28-view-your-command-line-history.ps1
@@ -10,5 +10,4 @@ $tip.Urls = @(
 	'https://learn.microsoft.com/powershell/module/psreadline/about/about_psreadline'
 	'https://learn.microsoft.com/powershell/module/microsoft.powershell.core/get-history'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Terminal

--- a/src/PowerShellTips/2023-09-05-when-checking-for-null-put-null-on-the-left.ps1
+++ b/src/PowerShellTips/2023-09-05-when-checking-for-null-put-null-on-the-left.ps1
@@ -14,5 +14,4 @@ $tip.Urls = @(
 	'https://powershellexplained.com/2018-12-23-Powershell-null-everything-you-wanted-to-know/'
 	'https://stackoverflow.com/a/60996703/602585'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-06-use-ctrlr-to-search-your-terminal-history.ps1
+++ b/src/PowerShellTips/2023-09-06-use-ctrlr-to-search-your-terminal-history.ps1
@@ -12,5 +12,4 @@ $tip.Example = ''
 $tip.Urls = @(
 	'https://woshub.com/powershell-commands-history/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Terminal # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-06-use-ctrlspace-to-list-all-parameters-properties-and-possibilities.ps1
+++ b/src/PowerShellTips/2023-09-06-use-ctrlspace-to-list-all-parameters-properties-and-possibilities.ps1
@@ -17,5 +17,4 @@ $tip.Example = @'
 $tip.Urls = @(
 	'https://blog.danskingdom.com/PowerShell-intellisense-on-the-command-line/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Terminal # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-11-ensure-prerequisites-are-met-by-using-requires.ps1
+++ b/src/PowerShellTips/2023-09-11-ensure-prerequisites-are-met-by-using-requires.ps1
@@ -19,5 +19,4 @@ $tip.Example = @'
 $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-11-join-the-monthly-powershell-community-call.ps1
+++ b/src/PowerShellTips/2023-09-11-join-the-monthly-powershell-community-call.ps1
@@ -12,5 +12,4 @@ $tip.Urls = @(
 	'https://powershell.org/series/powershell-community-call/'
 	'https://www.youtube.com/@powershellanddscteamchanne5739'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Community # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-11-read-and-write-excel-spreadsheets-with-importexcel.ps1
+++ b/src/PowerShellTips/2023-09-11-read-and-write-excel-spreadsheets-with-importexcel.ps1
@@ -23,5 +23,4 @@ $tip.Urls = @(
 	'https://www.powershellgallery.com/packages/ImportExcel'
 	'https://github.com/dfinke/ImportExcel'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Module # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-12-get-text-file-updates-in-realtime-with-get-content.ps1
+++ b/src/PowerShellTips/2023-09-12-get-text-file-updates-in-realtime-with-get-content.ps1
@@ -13,5 +13,4 @@ $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-content',
 	'https://4sysops.com/archives/parse-log-files-with-powershell/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::NativeCmdlet # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-16-use-out-gridview-to-view-and-select-tabular-data.ps1
+++ b/src/PowerShellTips/2023-09-16-use-out-gridview-to-view-and-select-tabular-data.ps1
@@ -11,5 +11,4 @@ $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/out-gridview'
 	'https://woshub.com/using-out-gridview-table-powershell/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::NativeCmdlet # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-17-use-f2-to-toggle-psreadline-predictions-to-list-view.ps1
+++ b/src/PowerShellTips/2023-09-17-use-f2-to-toggle-psreadline-predictions-to-list-view.ps1
@@ -13,5 +13,4 @@ $tip.Urls = @(
 	'https://devblogs.microsoft.com/powershell/announcing-psreadline-2-1-with-predictive-intellisense/'
 	'https://learn.microsoft.com/en-us/powershell/module/psreadline/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Terminal # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-18-split-long-lines-of-code-into-multiple-lines.ps1
+++ b/src/PowerShellTips/2023-09-18-split-long-lines-of-code-into-multiple-lines.ps1
@@ -35,5 +35,4 @@ Get-ChildItem `
 $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.3#line-continuation'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-19-use-splatting-for-nicer-code-and-dynamic-parameters.ps1
+++ b/src/PowerShellTips/2023-09-19-use-splatting-for-nicer-code-and-dynamic-parameters.ps1
@@ -26,5 +26,4 @@ $tip.Urls = @(
 	'https://adamtheautomator.com/powershell-splatting/'
 	'https://4sysops.com/archives/use-splatting-and-psboundparameters-to-pass-parameters-in-powershell/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-21-use-here-strings-for-hardcoded-multiline-strings.ps1
+++ b/src/PowerShellTips/2023-09-21-use-here-strings-for-hardcoded-multiline-strings.ps1
@@ -29,5 +29,4 @@ $tip.Urls = @(
 	'https://devblogs.microsoft.com/scripting/maximizing-the-power-of-here-string-in-powershell-for-configuration-data'
 
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-21-use-psboundparameters-to-check-if-a-parameter-was-provided.ps1
+++ b/src/PowerShellTips/2023-09-21-use-psboundparameters-to-check-if-a-parameter-was-provided.ps1
@@ -24,5 +24,4 @@ $tip.Urls = @(
 	'https://devblogs.microsoft.com/powershell/checking-for-bound-parameters/'
 	'https://www.reza-aghaei.com/how-to-determine-if-a-parameter-is-passed-to-a-powershell-cmdlet/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-22-avoid-array-addition.ps1
+++ b/src/PowerShellTips/2023-09-22-avoid-array-addition.ps1
@@ -27,5 +27,4 @@ foreach ($i in 0..10) {
 $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/performance/script-authoring-considerations?view=powershell-7.3#array-addition'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Performance # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-23-define-hardcoded-array-items-on-new-lines-without-commas.ps1
+++ b/src/PowerShellTips/2023-09-23-define-hardcoded-array-items-on-new-lines-without-commas.ps1
@@ -18,5 +18,4 @@ $tip.Example = @'
 $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-arrays?view=powershell-7.3#create-an-array'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-23-use-flags-to-allow-multiple-enum-values.ps1
+++ b/src/PowerShellTips/2023-09-23-use-flags-to-allow-multiple-enum-values.ps1
@@ -30,5 +30,4 @@ $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum#enumerations-as-flags'
 	'https://arcanecode.com/2021/12/06/fun-with-powershell-enum-flags/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-23-use-psversiontable-to-get-powershell-session-info.ps1
+++ b/src/PowerShellTips/2023-09-23-use-psversiontable-to-get-powershell-session-info.ps1
@@ -13,5 +13,4 @@ $PSVersionTable
 $tip.Urls = @(
 	'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables#psversiontable'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/PowerShellTips/2023-09-29-use-dynamic-values-in-validateset-while-maintaining-tab-completion.ps1
+++ b/src/PowerShellTips/2023-09-29-use-dynamic-values-in-validateset-while-maintaining-tab-completion.ps1
@@ -28,5 +28,4 @@ Test-ValidateSet -Value # Tab complete here to see the dynamic values.
 $tip.Urls = @(
 	'https://www.linkedin.com/feed/update/urn:li:activity:7113300637735407618/'
 )
-$tip.MinPowerShellVersion = '0.0'
 $tip.Category = [tiPS.TipCategory]::Syntax # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.

--- a/src/tiPS/Classes/PowerShellTip.Tests.ps1
+++ b/src/tiPS/Classes/PowerShellTip.Tests.ps1
@@ -9,7 +9,6 @@ Describe 'Trimming all tip properties' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
@@ -19,12 +18,10 @@ Describe 'Trimming all tip properties' {
 			[string] $tipText = 'Tip Text'
 			[string] $example = 'Example'
 			[string[]] $urls = @('https://Url1.com', 'http://Url2.com')
-			[string] $minPowerShellVersion = '5.1'
 			$tip.Title = $title
 			$tip.TipText = $tipText
 			$tip.Example = $example
 			$tip.Urls = $urls
-			$tip.MinPowerShellVersion = $minPowerShellVersion
 
 			{ $tip.TrimAllProperties() } | Should -Not -Throw
 
@@ -32,7 +29,6 @@ Describe 'Trimming all tip properties' {
 			$tip.TipText | Should -Be $tipText
 			$tip.Example | Should -Be $example
 			$tip.Urls | Should -Be $urls
-			$tip.MinPowerShellVersion | Should -Be $minPowerShellVersion
 		}
 	}
 
@@ -44,7 +40,6 @@ Describe 'Trimming all tip properties' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
@@ -58,13 +53,10 @@ Describe 'Trimming all tip properties' {
 			[string] $expectedExample = 'Example'
 			[string[]] $urls = @('https://Url1.com   ', '   http://Url2.com')
 			[string[]] $expectedUrls = @('https://Url1.com', 'http://Url2.com')
-			[string] $minPowerShellVersion = '5.1 '
-			[string] $expectedMinPowerShellVersion = '5.1'
 			$tip.Title = $title
 			$tip.TipText = $tipText
 			$tip.Example = $example
 			$tip.Urls = $urls
-			$tip.MinPowerShellVersion = $minPowerShellVersion
 
 			{ $tip.TrimAllProperties() } | Should -Not -Throw
 
@@ -72,7 +64,6 @@ Describe 'Trimming all tip properties' {
 			$tip.TipText | Should -Be $expectedTipText
 			$tip.Example | Should -Be $expectedExample
 			$tip.Urls | Should -Be $expectedUrls
-			$tip.MinPowerShellVersion | Should -Be $expectedMinPowerShellVersion
 		}
 	}
 }
@@ -86,7 +77,6 @@ Describe 'Validating a PowerShellTip' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
@@ -126,24 +116,6 @@ Describe 'Validating a PowerShellTip' {
 			{ $tip.Validate() } | Should -Throw
 		}
 
-		It 'Should throw an error when an invalid MinPowerShellVersion is supplied' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = 'Not a valid version'
-			{ $tip.Validate() } | Should -Throw
-		}
-
-		It 'Should throw an error when a version with a Build is supplied' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = '5.1.1'
-			{ $tip.Validate() } | Should -Throw
-		}
-
-		It 'Should throw an error when a version with a Revision is supplied' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = '5.1.0.1'
-			{ $tip.Validate() } | Should -Throw
-		}
-
 		It 'Should throw an error when an invalid Category is supplied' {
 			[tiPS.PowerShellTip] $tip = $ValidTip
 			{ $tip.Category = 'InvalidCategory' } | Should -Throw
@@ -158,24 +130,11 @@ Describe 'Validating a PowerShellTip' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
 		It 'Should not throw an error when all properties are valid' {
 			[tiPS.PowerShellTip] $tip = $ValidTip
-			{ $tip.Validate() } | Should -Not -Throw
-		}
-
-		It 'Should not throw an error when the MinPowerShellVersion is 0.0' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = '0.0'
-			{ $tip.Validate() } | Should -Not -Throw
-		}
-
-		It 'Should not throw an error when the MinPowerShellVersion is an empty string' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = ''
 			{ $tip.Validate() } | Should -Not -Throw
 		}
 	}
@@ -190,7 +149,6 @@ Describe 'Getting the Id property' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
@@ -219,7 +177,6 @@ Describe 'Checking if URLs are provided' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
@@ -238,7 +195,6 @@ Describe 'Checking if URLs are provided' {
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @()
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 
@@ -252,58 +208,6 @@ Describe 'Checking if URLs are provided' {
 			[tiPS.PowerShellTip] $tip = $ValidTip
 			$tip.Urls = $null
 			$tip.UrlsAreProvided | Should -BeFalse
-		}
-	}
-}
-
-Describe 'Checking if a MinPowerShellVersion was provided' {
-	Context 'Given the PowerShellTip has a MinPowerShellVersion' {
-		BeforeEach {
-			[tiPS.PowerShellTip] $ValidTip = [tiPS.PowerShellTip]::new()
-			$ValidTip.CreatedDate = [DateTime]::Parse('2023-07-16')
-			$ValidTip.Title = 'Title of the tip'
-			$ValidTip.TipText = 'Tip Text'
-			$ValidTip.Example = 'Example'
-			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
-			$ValidTip.Category = 'Community'
-		}
-
-		It 'Should return true when a MinPowerShellVersion is supplied' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = '5.1'
-			$tip.MinPowerShellVersionIsProvided | Should -BeTrue
-		}
-	}
-
-	Context 'Given the PowerShellTip does not have a MinPowerShellVersion' {
-		BeforeEach {
-			[tiPS.PowerShellTip] $ValidTip = [tiPS.PowerShellTip]::new()
-			$ValidTip.CreatedDate = [DateTime]::Parse('2023-07-16')
-			$ValidTip.Title = 'Title of the tip'
-			$ValidTip.TipText = 'Tip Text'
-			$ValidTip.Example = 'Example'
-			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '0.0'
-			$ValidTip.Category = 'Community'
-		}
-
-		It 'Should return false when the MinPowerShellVersion is 0.0' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = '0.0'
-			$tip.MinPowerShellVersionIsProvided | Should -BeFalse
-		}
-
-		It 'Should return false when the MinPowerShellVersion is an empty string' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = ''
-			$tip.MinPowerShellVersionIsProvided | Should -BeFalse
-		}
-
-		It 'Should return false when the MinPowerShellVersion is a whitespace string' {
-			[tiPS.PowerShellTip] $tip = $ValidTip
-			$tip.MinPowerShellVersion = ' '
-			$tip.MinPowerShellVersionIsProvided | Should -BeFalse
 		}
 	}
 }

--- a/src/tiPS/PowerShellTips.json
+++ b/src/tiPS/PowerShellTips.json
@@ -7,7 +7,6 @@
     "Urls": [
       "https://github.com/PowerShell/PowerShell"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 0
   },
   {
@@ -18,7 +17,6 @@
     "Urls": [
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -30,7 +28,6 @@
       "https://learn.microsoft.com/powershell/module/psreadline/about/about_psreadline",
       "https://learn.microsoft.com/powershell/module/microsoft.powershell.core/get-history"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 6
   },
   {
@@ -42,7 +39,6 @@
       "https://powershellexplained.com/2018-12-23-Powershell-null-everything-you-wanted-to-know/",
       "https://stackoverflow.com/a/60996703/602585"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -53,7 +49,6 @@
     "Urls": [
       "https://woshub.com/powershell-commands-history/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 6
   },
   {
@@ -64,7 +59,6 @@
     "Urls": [
       "https://blog.danskingdom.com/PowerShell-intellisense-on-the-command-line/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 6
   },
   {
@@ -75,7 +69,6 @@
     "Urls": [
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -88,7 +81,6 @@
       "https://powershell.org/series/powershell-community-call/",
       "https://www.youtube.com/@powershellanddscteamchanne5739"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 0
   },
   {
@@ -100,7 +92,6 @@
       "https://www.powershellgallery.com/packages/ImportExcel",
       "https://github.com/dfinke/ImportExcel"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 2
   },
   {
@@ -112,7 +103,6 @@
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-content",
       "https://4sysops.com/archives/parse-log-files-with-powershell/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 3
   },
   {
@@ -124,7 +114,6 @@
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/out-gridview",
       "https://woshub.com/using-out-gridview-table-powershell/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 3
   },
   {
@@ -136,7 +125,6 @@
       "https://devblogs.microsoft.com/powershell/announcing-psreadline-2-1-with-predictive-intellisense/",
       "https://learn.microsoft.com/en-us/powershell/module/psreadline/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 6
   },
   {
@@ -147,7 +135,6 @@
     "Urls": [
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.3#line-continuation"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -160,7 +147,6 @@
       "https://adamtheautomator.com/powershell-splatting/",
       "https://4sysops.com/archives/use-splatting-and-psboundparameters-to-pass-parameters-in-powershell/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -172,7 +158,6 @@
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules#here-strings",
       "https://devblogs.microsoft.com/scripting/maximizing-the-power-of-here-string-in-powershell-for-configuration-data"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -185,7 +170,6 @@
       "https://devblogs.microsoft.com/powershell/checking-for-bound-parameters/",
       "https://www.reza-aghaei.com/how-to-determine-if-a-parameter-is-passed-to-a-powershell-cmdlet/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -196,7 +180,6 @@
     "Urls": [
       "https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/performance/script-authoring-considerations?view=powershell-7.3#array-addition"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 4
   },
   {
@@ -207,7 +190,6 @@
     "Urls": [
       "https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-arrays?view=powershell-7.3#create-an-array"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -218,7 +200,6 @@
     "Urls": [
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables#psversiontable"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -230,7 +211,6 @@
       "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum#enumerations-as-flags",
       "https://arcanecode.com/2021/12/06/fun-with-powershell-enum-flags/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   },
   {
@@ -241,7 +221,6 @@
     "Urls": [
       "https://www.linkedin.com/feed/update/urn:li:activity:7113300637735407618/"
     ],
-    "MinPowerShellVersion": "0.0",
     "Category": 5
   }
 ]

--- a/src/tiPS/Private/TipsAlreadyShownFunctions.Tests.ps1
+++ b/src/tiPS/Private/TipsAlreadyShownFunctions.Tests.ps1
@@ -11,7 +11,6 @@ InModuleScope -ModuleName tiPS { # Must use InModuleScope to call private functi
 				$newTip.TipText = $tip.TipText
 				$newTip.Example = $tip.Example
 				$newTip.Urls = $tip.Urls
-				$newTip.MinPowerShellVersion = $tip.MinPowerShellVersion
 				$newTip.Category = $tip.Category
 				return $newTip
 			}
@@ -34,7 +33,6 @@ InModuleScope -ModuleName tiPS { # Must use InModuleScope to call private functi
 			$validTip.TipText = 'Tip Text'
 			$validTip.Example = 'Example'
 			$validTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$validTip.MinPowerShellVersion = '5.1'
 			$validTip.Category = 'Community'
 
 			# Clone our valid tip to make multiple instances.

--- a/src/tiPS/Private/WritePowerShellTipToTerminal.ps1
+++ b/src/tiPS/Private/WritePowerShellTipToTerminal.ps1
@@ -14,7 +14,6 @@ function WritePowerShellTipToTerminal
 	[ConsoleColor] $tipTextColor = [ConsoleColor]::White
 	[ConsoleColor] $exampleColor = [ConsoleColor]::Yellow
 	[ConsoleColor] $urlsColor = [ConsoleColor]::Green
-	[ConsoleColor] $minPowerShellVersionColor = [ConsoleColor]::Red
 
 	# Calculate how many header characters to put on each side of the title to make it look nice.
 	[int] $numberOfCharactersInHeader = 90
@@ -46,12 +45,6 @@ function WritePowerShellTipToTerminal
 	{
 		Write-Host 'More information: ' -ForegroundColor $urlsColor -NoNewline
 		Write-Host $Tip.Urls -ForegroundColor $urlsColor
-	}
-
-	if ($Tip.MinPowerShellVersionIsProvided)
-	{
-		Write-Host 'Required PowerShell version or greater: ' -ForegroundColor $minPowerShellVersionColor -NoNewline
-		Write-Host $Tip.MinPowerShellVersion -ForegroundColor $minPowerShellVersionColor
 	}
 
 	Write-Host ('-' * $numberOfCharactersInHeader) -ForegroundColor $headerColor

--- a/src/tiPS/Public/Get-PowerShellTip.Tests.ps1
+++ b/src/tiPS/Public/Get-PowerShellTip.Tests.ps1
@@ -100,7 +100,6 @@ InModuleScope -ModuleName tiPS { # Must use InModuleScope to access script-level
 			$ValidTip.TipText = 'Tip Text'
 			$ValidTip.Example = 'Example'
 			$ValidTip.Urls = @('https://Url1.com', 'http://Url2.com')
-			$ValidTip.MinPowerShellVersion = '5.1'
 			$ValidTip.Category = 'Community'
 		}
 

--- a/tools/New-PowerShellTip.ps1
+++ b/tools/New-PowerShellTip.ps1
@@ -22,6 +22,8 @@ $dummyTip.Title = $tipTitle.Trim()
 A short description of the tip.
 
 This can be multiple lines.
+
+If tip is for a new feature, mention the PowerShell version the tip was introduced in.
 '@
 `$tip.Example = @'
 Example code to demonstrate the tip. This can also be multiple lines if needed.
@@ -30,7 +32,6 @@ Example code to demonstrate the tip. This can also be multiple lines if needed.
 	'https://OneTwoOrThreeUrls'
 	'https://ToLearnMoreAboutTheTip'
 )
-`$tip.MinPowerShellVersion = '0.0'
 `$tip.Category = [tiPS.TipCategory]::Other # Community, Editor, Module, NativeCmdlet, Performance, Syntax, Terminal, or Other.
 "@
 


### PR DESCRIPTION
Remove the MinPowerShellVersion tip property, as it is not used often enough to be a 1st class property