### PR TITLE
ci: Have build trigger deployment explicitly

### DIFF
--- a/.github/workflows/build-and-test-powershell-module.yml
+++ b/.github/workflows/build-and-test-powershell-module.yml
@@ -262,7 +262,10 @@ jobs:
           name: ${{ env.deployFilesArtifactName }}
           path: ${{ env.deployFilesArtifactDirectoryPath }}
 
-      - name: Trigger the deployment workflow
-        uses: ./.github/workflows/deploy-powershell-module.yml
-        with:
-          buildWorkflowRunId: ${{ github.run_id }}
+  trigger-deployment:
+    needs: build-and-test
+    # Only trigger a deployment if this build is for a push (not a PR) and is for the default branch (main).
+    if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    uses: ./.github/workflows/deploy-powershell-module.yml
+    with:
+      buildWorkflowRunId: ${{ github.run_id }}

--- a/.github/workflows/build-and-test-powershell-module.yml
+++ b/.github/workflows/build-and-test-powershell-module.yml
@@ -261,3 +261,8 @@ jobs:
         with:
           name: ${{ env.deployFilesArtifactName }}
           path: ${{ env.deployFilesArtifactDirectoryPath }}
+
+      - name: Trigger the deployment workflow
+        uses: ./.github/workflows/deploy-powershell-module.yml
+        with:
+          buildWorkflowRunId: ${{ github.run_id }}

--- a/.github/workflows/deploy-powershell-module.yml
+++ b/.github/workflows/deploy-powershell-module.yml
@@ -1,18 +1,20 @@
 name: deploy
 
 on:
-  workflow_run:
-    workflows: [build]
-    types: [completed]
-    branches: [main]
+  workflow_call:
+    inputs:
+      buildWorkflowRunId:
+        description: 'The build workflow run ID containing the artifacts to use.'
+        required: true
+        type: number
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
-      workflowRunId:
+      buildWorkflowRunId:
         description: 'The build workflow run ID containing the artifacts to use. The run ID can be found in the URL of the build workflow run.'
-        type: number
         required: true
+        type: number
 
 env:
   powerShellModuleName: 'tiPS' # Must match the name in the build workflow.
@@ -20,12 +22,9 @@ env:
   stableModuleArtifactName: 'StableModuleArtifact' # Must match the name in the build workflow.
   deployFilesArtifactName: 'DeployFilesArtifact' # Must match the name in the build workflow.
   artifactsDirectoryPath: './artifacts'
-  workflowRunId: ${{ github.event_name == 'workflow_dispatch' && inputs.workflowRunId || github.event.workflow_run.id }} # Ternary operator to use input value if manually triggered, otherwise use the workflow_run.id value.
 
 jobs:
   publish-prerelease-module:
-    # Only run the deployment if manually triggered, or the build workflow succeeded.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       prereleaseVersionNumber: ${{ steps.output-version-number.outputs.prereleaseVersionNumber }}
@@ -33,7 +32,7 @@ jobs:
       - name: Download prerelease module artifact from triggered workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ env.workflowRunId }}
+          run_id: ${{ inputs.buildWorkflowRunId }}
           name: ${{ env.prereleaseModuleArtifactName}}
           path: ${{ env.artifactsDirectoryPath }}
           search_artifacts: true
@@ -85,7 +84,7 @@ jobs:
       - name: Download deploy files artifact from triggered workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ env.workflowRunId }}
+          run_id: ${{ inputs.buildWorkflowRunId }}
           name: ${{ env.deployFilesArtifactName}}
           path: ${{ env.artifactsDirectoryPath }}
           search_artifacts: true
@@ -128,7 +127,7 @@ jobs:
       - name: Download deploy files artifact from triggered workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ env.workflowRunId }}
+          run_id: ${{ inputs.buildWorkflowRunId }}
           name: ${{ env.deployFilesArtifactName}}
           path: ${{ env.artifactsDirectoryPath }}
           search_artifacts: true
@@ -161,7 +160,7 @@ jobs:
       - name: Download stable module artifact from triggered workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ env.workflowRunId }}
+          run_id: ${{ inputs.buildWorkflowRunId }}
           name: ${{ env.stableModuleArtifactName}}
           path: ${{ env.artifactsDirectoryPath }}
           search_artifacts: true
@@ -211,7 +210,7 @@ jobs:
       - name: Download deploy files artifact from triggered workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ env.workflowRunId }}
+          run_id: ${{ inputs.buildWorkflowRunId }}
           name: ${{ env.deployFilesArtifactName}}
           path: ${{ env.artifactsDirectoryPath }}
           search_artifacts: true
@@ -254,7 +253,7 @@ jobs:
       - name: Download deploy files artifact from triggered workflow
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ env.workflowRunId }}
+          run_id: ${{ inputs.buildWorkflowRunId }}
           name: ${{ env.deployFilesArtifactName}}
           path: ${{ env.artifactsDirectoryPath }}
           search_artifacts: true

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
 	"ignoreWords": [
 		"Codespace", // GitHub Codespaces
 		"Codespaces", // GitHub Codespaces
+		"dawidd", // GitHub action author
 		"devcontainer", // VS Code devcontainer
 		"hashtable", // PowerShell Hashtable
 		"Hmmss", // Time format


### PR DESCRIPTION
Previously we had the deployment workflow trigger when a build workflow completed. The problem is that the deployment workflow would trigger even if the build workflow failed; GitHub Actions does not provide a way of only triggering a workflow only if the dependent workflow succeeded.

To solve this problem we are reversing the dependency. Instead of the deployment workflow listening for the build workflow to complete, the build workflow will explicitly trigger the deployment workflow, and only when it completes successfully.