### PR TITLE
chore: Version C# assemblies too

### DIFF
--- a/.github/workflows/build-and-test-powershell-module.yml
+++ b/.github/workflows/build-and-test-powershell-module.yml
@@ -62,9 +62,42 @@ jobs:
         shell: pwsh
         run: $PSVersionTable
 
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0
+        with:
+          versionSpec: '5.x'
+
+      - name: Get git metadata used for new version number
+        id: git-version
+        uses: gittools/actions/gitversion/execute@v0
+
+      - name: Determine the new version number
+        shell: pwsh
+        run: |
+          [string] $newVersionNumber = '${{ steps.git-version.outputs.majorMinorPatch }}'
+          [string] $prereleaseLabel = '${{ steps.git-version.outputs.preReleaseTag }}'
+
+          [string] $manuallyProvidedVersionNumber = '${{ inputs.versionNumber }}'
+          if (-not [string]::IsNullOrWhiteSpace($manuallyProvidedVersionNumber)) {
+            Write-Output "Using manually provided version number '$manuallyProvidedVersionNumber'."
+            $newVersionNumber = $manuallyProvidedVersionNumber
+          }
+
+          # The preReleaseTag is empty when building the default branch, so manually create a prerelease version number if needed.
+          if ([string]::IsNullOrWhiteSpace($prereleaseLabel)) {
+            [string] $dateTime = (Get-Date -Format 'yyyyMMddTHHmmss')
+            $prereleaseLabel = $dateTime + 'SHA' + '${{ steps.git-version.outputs.shortSha }}'
+          }
+          # PowerShell prerelease labels can only contain the characters 'a-zA-Z0-9', so sanitize it if needed.
+          $newVersionNumberPrereleaseLabel = $prereleaseLabel -replace '[^a-zA-Z0-9]', ''
+
+          Write-Output "Setting new environment variables 'NewVersionNumberMajorMinorPatch=$newVersionNumber' and 'NewVersionNumberPrereleaseLabel=$newVersionNumberPrereleaseLabel'."
+          "NewVersionNumberMajorMinorPatch=$newVersionNumber" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          "NewVersionNumberPrereleaseLabel=$newVersionNumberPrereleaseLabel" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Build the C# assemblies
         shell: pwsh
-        run: ./build/Build-CSharpAssemblies.ps1 -Force
+        run: ./build/Build-CSharpAssemblies.ps1 -VersionNumber '${{ steps.git-version.outputs.assemblySemVer }}' -Force
 
       - name: Generate PowerShellTips.json file
         shell: pwsh
@@ -126,39 +159,6 @@ jobs:
             CodeCoverage = @{ Enabled = $false }
           }
           Invoke-Pester -Configuration $pesterConfig
-
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0
-        with:
-          versionSpec: '5.x'
-
-      - name: Get git metadata used for new version number
-        id: git-version
-        uses: gittools/actions/gitversion/execute@v0
-
-      - name: Determine the new version number
-        shell: pwsh
-        run: |
-          [string] $newVersionNumber = '${{ steps.git-version.outputs.majorMinorPatch }}'
-          [string] $prereleaseLabel = '${{ steps.git-version.outputs.preReleaseTag }}'
-
-          [string] $manuallyProvidedVersionNumber = '${{ inputs.versionNumber }}'
-          if (-not [string]::IsNullOrWhiteSpace($manuallyProvidedVersionNumber)) {
-            Write-Output "Using manually provided version number '$manuallyProvidedVersionNumber'."
-            $newVersionNumber = $manuallyProvidedVersionNumber
-          }
-
-          # The preReleaseTag is empty when building the default branch, so manually create a prerelease version number if needed.
-          if ([string]::IsNullOrWhiteSpace($prereleaseLabel)) {
-            [string] $dateTime = (Get-Date -Format 'yyyyMMddTHHmmss')
-            $prereleaseLabel = 'ci' + $dateTime + 'SHA' + '${{ steps.git-version.outputs.shortSha }}'
-          }
-          # PowerShell prerelease labels can only contain the characters 'a-zA-Z0-9', so sanitize it if needed.
-          $newVersionNumberPrereleaseLabel = $prereleaseLabel -replace '[^a-zA-Z0-9]', ''
-
-          Write-Output "Setting new environment variables 'NewVersionNumberMajorMinorPatch=$newVersionNumber' and 'NewVersionNumberPrereleaseLabel=$newVersionNumberPrereleaseLabel'."
-          "NewVersionNumberMajorMinorPatch=$newVersionNumber" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          "NewVersionNumberPrereleaseLabel=$newVersionNumberPrereleaseLabel" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Create Stable and Prerelease module artifacts
         shell: pwsh

--- a/build/Build-CSharpAssemblies.ps1
+++ b/build/Build-CSharpAssemblies.ps1
@@ -32,7 +32,7 @@ if ($removeDllFilesError)
 	throw "Error deleting the DLL files in '$moduleClassesDirectoryPath'. They are likely in use by another process that imported tiPS. Try closing all PowerShell sessions and running the script again. Error: $removeDllFilesError"
 }
 
-Write-Output "Building C# sln '$csharpSlnFilePath' in Release mode."
+Write-Output "Building C# sln '$csharpSlnFilePath' in Release mode with version number '$VersionNumber'."
 & dotnet build "$csharpSlnFilePath" --configuration Release -p:Version=$VersionNumber
 
 Write-Output "Copying the DLL files in '$csharpClassesDllDirectoryPath' to the module's Classes directory '$moduleClassesDirectoryPath'."

--- a/build/Build-CSharpAssemblies.ps1
+++ b/build/Build-CSharpAssemblies.ps1
@@ -3,6 +3,9 @@
 [CmdletBinding()]
 Param
 (
+	[Parameter(Mandatory = $false, HelpMessage = 'The version number to build the assemblies with, in the format "Major.Minor.Build.Revision". Default is "1.0.0.0".')]
+	[string] $VersionNumber = '1.0.0.0',
+
 	[Parameter(Mandatory = $false, HelpMessage = 'If specified, the module DLL files will be rebuilt even if they already exist. Otherwise, they will only be built if they do not exist.')]
 	[switch] $Force
 )
@@ -30,7 +33,7 @@ if ($removeDllFilesError)
 }
 
 Write-Output "Building C# sln '$csharpSlnFilePath' in Release mode."
-& dotnet build "$csharpSlnFilePath" --configuration Release
+& dotnet build "$csharpSlnFilePath" --configuration Release -p:Version=$VersionNumber
 
 Write-Output "Copying the DLL files in '$csharpClassesDllDirectoryPath' to the module's Classes directory '$moduleClassesDirectoryPath'."
 Copy-Item -Path "$csharpClassesDllDirectoryPath/*" -Destination $moduleClassesDirectoryPath -Include '*.dll' -Force


### PR DESCRIPTION
chore: Version C# assemblies too
ci: Remove 'ci' prefix on prerelease version numbers