### PR TITLE
fix: Write time using round-trip format instead of OS-specific format to avoid parse errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,12 @@
 This page is a list of _notable_ changes made in each version.
 Every time a tip is added the patch version is incremented, so there will be a lot of patch version changes not documented here.
 
+## v1.3.7 - May 20, 2024
+
+Fixes:
+
+- Write module's last auto-update time and last auto-write tip time to file using a universal format instead of an OS-dependent format to avoid errors parsing the datetime when the module loads.
+
 ## v1.3.0 - April 20, 2024
 
 Features:

--- a/src/tiPS/Private/AutomaticModuleUpdateFunctions.ps1
+++ b/src/tiPS/Private/AutomaticModuleUpdateFunctions.ps1
@@ -90,7 +90,7 @@ function WriteModulesLastUpdateDate
 
 	[string] $moduleUpdateDateFilePath = GetModulesLastUpdateDateFilePath
 	Write-Verbose "Writing modules last update date '$ModulesLastUpdateDate' to '$moduleUpdateDateFilePath'."
-	[System.IO.File]::WriteAllText($moduleUpdateDateFilePath, $ModulesLastUpdateDate.ToString())
+	[System.IO.File]::WriteAllText($moduleUpdateDateFilePath, $ModulesLastUpdateDate.ToString('o'))
 }
 
 function GetModulesLastUpdateDateFilePath

--- a/src/tiPS/Private/AutomaticWritePowerShellTipFunctions.ps1
+++ b/src/tiPS/Private/AutomaticWritePowerShellTipFunctions.ps1
@@ -122,7 +122,7 @@ function WriteLastAutomaticTipWrittenDate
 
 	[string] $lastAutomaticTipWrittenDateFilePath = GetLastAutomaticTipWrittenDateFilePath
 	Write-Verbose "Writing last automatic tip Written date '$LastAutomaticTipWrittenDate' to '$lastAutomaticTipWrittenDateFilePath'."
-	[System.IO.File]::WriteAllText($lastAutomaticTipWrittenDateFilePath, $LastAutomaticTipWrittenDate.ToString())
+	[System.IO.File]::WriteAllText($lastAutomaticTipWrittenDateFilePath, $LastAutomaticTipWrittenDate.ToString('o'))
 }
 
 function GetLastAutomaticTipWrittenDateFilePath


### PR DESCRIPTION
### Summary

fix: Write time using round-trip format instead of OS-specific format to avoid parse errors

Fixes Bug #60

### Checklist

Addresses issue #ISSUE_NUMBER (if applicable)

- [x] Tests have been added for this code change (if applicable)
   - Tests added [in separate change outside of this PR](https://github.com/deadlydog/PowerShell.tiPS/commit/f04be35951a29b23890298cd61478fe6043e1b26)
- [x] Docs have been added or updated (if applicable)
- [x] Code format follows the project style
- [x] All new and existing tests passed

### What type of changes does this PR include

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
