### PR TITLE
chore: Add VS Code task to run CSpell locally

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,6 +9,7 @@
 		".devcontainer/devcontainer.json",
 		".github/workflows/build-and-test-powershell-module.yml",
 		".github/workflows/build-test-and-deploy-powershell-module.yml",
+		".gitignore",
 		"src/tiPS/PowerShellTips.json",
 		"**/bin/**", // Ignore C# build output files.
 		"**/obj/**" // Ignore C# build output files.

--- a/.cspell.json
+++ b/.cspell.json
@@ -10,8 +10,8 @@
 		".github/workflows/build-and-test-powershell-module.yml",
 		".github/workflows/build-test-and-deploy-powershell-module.yml",
 		"src/tiPS/PowerShellTips.json",
-		"**/bin/**",
-		"**/obj/**"
+		"**/bin/**", // Ignore C# build output files.
+		"**/obj/**" // Ignore C# build output files.
 	],
 	"words": [
 		"colours",

--- a/.cspell.json
+++ b/.cspell.json
@@ -9,7 +9,9 @@
 		".devcontainer/devcontainer.json",
 		".github/workflows/build-and-test-powershell-module.yml",
 		".github/workflows/build-test-and-deploy-powershell-module.yml",
-		"src/tiPS/PowerShellTips.json"
+		"src/tiPS/PowerShellTips.json",
+		"**/bin/**",
+		"**/obj/**"
 	],
 	"words": [
 		"colours",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 		"ghcr.io/devcontainers/features/dotnet:2": "latest" // Installs the dotnet CLI.
 	},
 
-	// Set pwsh as the default shell for the devcontainer, install required PowerShell modules, and install NPM.
+	// Set pwsh as the default shell for the devcontainer, install required PowerShell modules, and install NPM and CSpell.
 	"postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"; pwsh -c \"Install-Module Pester -Force\"; pwsh -c \"Install-Module PSScriptAnalyzer -Force\"; sudo apt update; sudo DEBIAN_FRONTEND=noninteractive apt install -y npm; npm install cspell",
 
 	// Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "PowerShell",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/powershell:lts-debian-11",
+	"image": "mcr.microsoft.com/dotnet/sdk:9.0",
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installZsh": "true",
@@ -11,10 +11,11 @@
 			"upgradePackages": "false",
 			"nonFreePackages": "true"
 		},
-		"ghcr.io/devcontainers/features/dotnet:2": "latest"
+		"ghcr.io/devcontainers/features/dotnet:2": "latest" // Installs the dotnet CLI.
 	},
 
-	"postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"; pwsh -c 'install-module Pester -force'; pwsh -c 'install-module PSScriptAnalyzer -force'",
+	// Set pwsh as the default shell for the devcontainer, install required PowerShell modules, and install NPM.
+	"postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"; pwsh -c \"Install-Module Pester -Force\"; pwsh -c \"Install-Module PSScriptAnalyzer -Force\"; sudo apt update; sudo DEBIAN_FRONTEND=noninteractive apt install -y npm; npm install cspell",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# Ignore Pester code coverage report file
+# Ignore Pester code coverage report file.
 coverage.xml
+
+# Ignore NPM files.
+package-lock.json
+package.json
 
 # Created by https://www.gitignore.io/api/powershell,visualstudio,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=powershell,visualstudio,visualstudiocode

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,7 @@
 			},
 			"dependsOn": [
 				"Run PSScriptAnalyzer linter",
+				"Run CSpell spell checker",
 				"Convert PowerShellTips files to JSON file"
 			]
 		},
@@ -36,6 +37,30 @@
 				}
 			},
 			"command": "Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit",
+			"group": "build",
+			"presentation": {
+				"reveal": "always",
+				"panel": "dedicated",
+				"clear": true,
+				"group": "build"
+			},
+			"problemMatcher": [
+				"$func-powershell-watch"
+			]
+		},
+		{
+			"label": "Run CSpell spell checker",
+			"type": "shell",
+			"options": {
+				"shell": {
+					"executable": "pwsh",
+					"args": [
+						"-NoProfile",
+						"-Command"
+					]
+				}
+			},
+			"command": "try { & npx -v > $null } catch {}; if ($?) { & npx cspell . } else { Write-Warning 'Node.js is not installed, so cannot download and run npx cspell.' }",
 			"group": "build",
 			"presentation": {
 				"reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,6 +60,7 @@
 					]
 				}
 			},
+			// If npx is not available, warn that Node.js is not installed. If we cannot run cspell, try to install and run it, and warn if we still cannot run it.
 			"command": "try { & npx -v > $null } catch {}; if (-not $?) { Write-Warning 'Node.js is not installed, so cannot download and run npx cspell.' } else { try { & npx cspell . } catch {}; if (-not $?) { & npm install cspell; & npx cspell . }; if (-not $?) { Write-Warning 'There was a problem installing or running cspell' } }",
 			"group": "build",
 			"presentation": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,7 +60,7 @@
 					]
 				}
 			},
-			"command": "try { & npx -v > $null } catch {}; if ($?) { & npx cspell . } else { Write-Warning 'Node.js is not installed, so cannot download and run npx cspell.' }",
+			"command": "try { & npx -v > $null } catch {}; if (-not $?) { Write-Warning 'Node.js is not installed, so cannot download and run npx cspell.' } else { try { & npx cspell . } catch {}; if (-not $?) { & npm install cspell; & npx cspell . }; if (-not $?) { Write-Warning 'There was a problem installing or running cspell' } }",
 			"group": "build",
 			"presentation": {
 				"reveal": "always",

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -72,6 +72,8 @@ The build process performs the following operations:
 1. Generate the PowerShellTips.json file from the files in the PowerShellTips directory.
    1. [This ADR](/docs/ArchitectureDecisionRecords/004-Save-all-tips-to-a-single-file.md) explains why we save all of the tips to a single file.
 1. Run the PSScriptAnalyzer linter on all of the PowerShell files.
+1. Run the CSpell spell checker on all files to find any spelling mistakes.
+   1. If CSpell flags a word that is not actually misspelled, you can add it to the `.cspell.json` file in the root of the repository.
 1. (Pipeline build only) Concatenate all of the PowerShell file contents into the psm1 file, and delete the ps1 files.
    1. [This ADR](/docs/ArchitectureDecisionRecords/005-How-to-dot-source-files-into-the-module-psm1-file.md) explains why we concatenate the files into the psm1 file.
 


### PR DESCRIPTION
### Summary

chore: Add VS Code task to run CSpell locally, and ignore files in /bin and /obj directories.

### Checklist

- [x] Tests have been added for this code change (if applicable)
- [x] Docs have been added or updated (if applicable)
- [x] Code format follows the project style
- [x] All new and existing tests passed

### What type of changes does this PR include

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Describe the change in more detail

Allows users to run the CSpell spellcheck tool locally before pushing their code up to a PR to see if it will pass there.
